### PR TITLE
FIx for Puppet 4 compatibility

### DIFF
--- a/manifests/download.pp
+++ b/manifests/download.pp
@@ -25,7 +25,7 @@
 #
 define r9util::download(
   $url     = $title,
-  $timeout = 300,
+  $timeout = '300',
   $path    = undef,
   $md5sum  = undef,
 ){


### PR DESCRIPTION
On Puppet 4 this change fixes an error like:
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, undefined method `length' for 300:Fixnum at /etc/puppetlabs/code/environments/example42/modules/r9util/manifests/download.pp:46:16